### PR TITLE
AsyncClient/Enh: expose close method into AsyncClient to use in async…

### DIFF
--- a/openapi-python-templates/api.mustache
+++ b/openapi-python-templates/api.mustache
@@ -127,7 +127,14 @@ class _{{classname}}:
 
 {{#operations}}
 class Async{{classname}}(_{{classname}}):
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.api_client.close()
 {{#operation}}
+
     async def {{operationId}}(self, {{#allParams}}{{#required}}{{paramName}}: {{>_dataTypeApi}}{{/required}}{{^required}}{{paramName}}: {{>_dataTypeApi}} = None{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> {{>_returnType}}:
 {{#notes}}
         """

--- a/openapi-python-templates/api_client.mustache
+++ b/openapi-python-templates/api_client.mustache
@@ -37,6 +37,9 @@ class ApiClient:
         self.middleware: MiddlewareT = BaseMiddleware()
         self._async_client = AsyncClient(**kwargs)
 
+    async def close(self):
+        await self._async_client.aclose()
+
     @overload
     async def request(
         self, *, type_: Type[T], method: str, url: str, path_params: Dict[str, Any] = None, **kwargs: Any


### PR DESCRIPTION
- Expose close method into AsyncClient class
- Implement '__aenter__' and '__aexit__'  methods in Async api client to be able to use "async with" statement to get closed automatically the httpx client.